### PR TITLE
Bug/66

### DIFF
--- a/front/src/apis/useFetchingMap.js
+++ b/front/src/apis/useFetchingMap.js
@@ -1,15 +1,15 @@
 import { useGetMyLoc } from 'apis/useGetMyLoc';
 
-const { kakao } = window;
+var { kakao } = window;
 
 export default function useFetchingMap() {
   // console.log(`useFetchingMap`);
-  const container = document.getElementById('Map'); // 가이드는 Map이다
-  const options = {
+  var container = document.getElementById('Map'); // 가이드는 Map이다
+  var options = {
     center: new kakao.maps.LatLng(33.450701, 126.570667),
     level: 3,
   };
-  const map = new kakao.maps.Map(container, options);
+  var map = new kakao.maps.Map(container, options);
 
   useGetMyLoc();
 

--- a/front/src/apis/useGetMyLoc.js
+++ b/front/src/apis/useGetMyLoc.js
@@ -2,15 +2,15 @@ import pepsi from 'apis/license/pepsi.png';
 import coca from 'apis/license/coca.png';
 import marker from 'apis/license/marker.png';
 
-const { kakao } = window;
+var { kakao } = window;
 
 export function useGetMyLoc() {
-  const container = document.getElementById('Map'); // 가이드는 Map이다
-  const options = {
+  var container = document.getElementById('Map'); // 가이드는 Map이다
+  var options = {
     center: new kakao.maps.LatLng(33.450701, 126.570667),
     level: 3,
   };
-  const map = new kakao.maps.Map(container, options);
+  var map = new kakao.maps.Map(container, options);
 
   // HTML5의 geolocation으로 사용할 수 있는지 확인합니다
   if (navigator.geolocation) {
@@ -33,7 +33,7 @@ export function useGetMyLoc() {
   function displayMarker(positions) {
     // console.log('positions 배열 출력:', positions);
     for (var i = 0; i < positions.length; i++) {
-      const imageSize = new kakao.maps.Size(25, 35);
+      var imageSize = new kakao.maps.Size(25, 35);
 
       // 마커 이미지를 위한 변수
       let markerImage;

--- a/front/src/apis/useGetSearchData.js
+++ b/front/src/apis/useGetSearchData.js
@@ -1,6 +1,6 @@
 // Search Input에서 onchange를 통해 검색된 결과물을 담는 함수
 
-const { kakao } = window;
+var { kakao } = window;
 
 var ps = new kakao.maps.services.Places();
 

--- a/front/src/apis/useKeyword.js
+++ b/front/src/apis/useKeyword.js
@@ -1,18 +1,18 @@
 import markerImg from 'apis/license/marker.png';
 // useGetSearchData를 바탕으로 검색된 데이터를 지도에 표시하기 위한 함수
 
-const { kakao } = window;
+var { kakao } = window;
 
 export function useKeyword(searchValue) {
   // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
   var infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
 
-  const container = document.getElementById('Map'); // 가이드는 Map이다
-  const options = {
+  var container = document.getElementById('Map'); // 가이드는 Map이다
+  var options = {
     center: new kakao.maps.LatLng(33.450701, 126.570667),
     level: 2,
   };
-  const map = new kakao.maps.Map(container, options);
+  var map = new kakao.maps.Map(container, options);
 
   // 장소 검색 객체를 생성합니다
   var ps = new kakao.maps.services.Places();

--- a/front/src/pages/Personal/index.js
+++ b/front/src/pages/Personal/index.js
@@ -44,7 +44,7 @@ const Personal = () => {
   useEffect(() => {
     // LS에 Token은 있는데 storeData가 없으면 (로그인 정보가 있는데 storeData가 없으면) > dispatch
     if (canLoad) {
-      console.log('myInfo', myInfo);
+      // console.log('myInfo', myInfo);
       dispatch({
         // 내가 제보한 포스트 불러오기
         type: LOAD_MY_POSTS_REQUEST,

--- a/front/src/sagas/personal.js
+++ b/front/src/sagas/personal.js
@@ -104,7 +104,7 @@ function loadMyPostsAPI() {
         Authorization: 'Bearer ' + localStorage.getItem('token'),
       },
     };
-    console.log('isToken and axios data: ', localStorage.getItem('token'));
+    // console.log('isToken and axios data: ', localStorage.getItem('token'));
 
     return axios.get('/post/user', tokenConfig);
   } else {
@@ -114,10 +114,10 @@ function loadMyPostsAPI() {
 }
 
 function* loadMyPostsRequest(action) {
-  console.log('loadMyPostsRequest action: ', action);
+  // console.log('loadMyPostsRequest action: ', action);
   try {
     const result = yield call(loadMyPostsAPI);
-    console.log('load my posts result:', result.data.posts);
+    // console.log('load my posts result:', result.data.posts);
     yield put({
       type: LOAD_MY_POSTS_SUCCESS,
       data: result.data.posts,

--- a/front/src/sagas/personal.js
+++ b/front/src/sagas/personal.js
@@ -23,6 +23,7 @@ function checkUserAPI() {
 function* checkUserRequest() {
   try {
     const result = yield call(checkUserAPI);
+    // console.log('checkUserRequest.result:', result);
     yield put({
       type: CHECK_USER_SUCCESS,
       data: result.data,
@@ -90,10 +91,22 @@ function* logOutRequest() {
 
 function loadMyPostsAPI() {
   // 로그인 후에 > 바로 personal 페이지에 접근 시, myConfig(로컬 스토리지에 저장된 나의 토큰) 확인
-  console.log('myConfig:', myConfig);
+  // console.log('myConfig:', myConfig);
   if (localStorage.getItem('token')) {
+    /* 
+    사가 인덱스에서 export한 myConfig를 로그인 후, 첫 번쩨 요청시 토큰을 감지하지 못하는 오류가 있음
+    loadMyPostsAPI 함수 내부에서 헤더를 다시 만들어 주었다.
+    */
+
+    // axios 데이터와 함께 보낼 헤더
+    const tokenConfig = {
+      headers: {
+        Authorization: 'Bearer ' + localStorage.getItem('token'),
+      },
+    };
     console.log('isToken and axios data: ', localStorage.getItem('token'));
-    return axios.get('/post/user', myConfig);
+
+    return axios.get('/post/user', tokenConfig);
   } else {
     console.log('isnt Token...');
     return;


### PR DESCRIPTION
## #66

## PR 설명
- BUG REPORT 내용 fix

## 📝 버그 내용

### 1.로그인 관련

- 첫 로그인 이후 개인 페이지 접근 시 헤더에 넣을 토큰을 불러오지 못하는 상황
- 그에 따라 새로 고침을 해야 로컬스토리지에 저장한 토큰을 정상적으로 불러오는 번거로운 상황 발생

- kakao API에 사용된 키워드 수정

## 🐛 버그 발생 상황
- 버그가 발생한 상황에 대한 과정 설명

1. 첫 번째 로그인 시도 이후, 개인 페이지로 들어가 정보를 요청할 때 헤더에 보낼 토큰 정보가 들어가지 않음

https://user-images.githubusercontent.com/54658162/127606685-004e0ed3-ce26-42be-b97e-e2761af7d4be.mov

2. myconfig 변수를 통해 헤더에 보낼 값인 토큰이 비어 있는 상태

<img width="546" alt="스크린샷 2021-07-30 오후 2 47 22" src="https://user-images.githubusercontent.com/54658162/127606840-06d5894c-4e5d-40ca-a70a-1c1439aec79e.png">

3. ssagas/index의 해당 코드

```js
/* 헤더에 넣어 보낼 사용자의 토큰 */
export const myConfig = {
  headers: {
    Authorization: 'Bearer ' + localStorage.getItem('token'),
  },
};
```

### 카카오 API 관련

```js
var { kakao } = window;
```

- 카카오에서 위와 같이 var 키워드를 써서 kakao 변수를 나타낸 이유는 해당 변수를 전역 객체로 쓰기 위함임
- let 또는 const 키워드를 사용한다면 해당 변수는 전역 객체로 사용할 수 없음
- 따라서 카카오 제공 환경에 맞게 다시 var 키워드로 변경하였음

<a href="https://github.com/junh0328/upgrade_javascript/blob/master/DEEPDIVE/readme2.md#%EC%A0%84%EC%97%AD-%EA%B0%9D%EC%B2%B4">전역 객체 바로가기</a>

## 📈 기대한 결과
- 개인 페이지 접근 시, 로컬 스토리지에 저장된 정보를 sagas/index의 myConfig에서 정상적으로 담아 요청을 보내려고 했음
- redux-saga 미들웨어의 동작에 대한 개념이 부족한 것 같음

## 💻 버그 발생 환경
- Browser [브라우저 전체]
- Mobile [IOS]
